### PR TITLE
Don't add sensors that haven't run to slack handler

### DIFF
--- a/src/Command/CheckSensorsLastRunCommand.php
+++ b/src/Command/CheckSensorsLastRunCommand.php
@@ -76,6 +76,11 @@ class CheckSensorsLastRunCommand extends Command
 
             $configuredInterval = $config['checks'][$key]['interval'];
 
+            if (!isset($lastRunResults[$key])) {
+                // this hasn't run
+                continue;
+            }
+
             $lastRunTime = $lastRunResults[$key]['check']['executed'];
 
             $lastRun = new DateTime();


### PR DESCRIPTION
This will keep new sensors that have just been deployed from alerting slack.

They will appear in slack, once they have run once and then have not run for a while.