### PR TITLE
Feature/display warning for new sensors

### DIFF
--- a/bin/sensu-dashboard
+++ b/bin/sensu-dashboard
@@ -4,6 +4,7 @@ require_once __DIR__ . '/../bootstrap.php';
 
 use SensuDashboard\Command\CheckSensorsLastRunCommand;
 use SensuDashboard\Service\SensuApiService;
+use SensuDashboard\Service\SensuConfigService;
 use Symfony\Component\Console\Application;
 
 $application = new Application();
@@ -13,7 +14,7 @@ $container = $app->getContainer();
 //Commands
 $application->add(
             new CheckSensorsLastRunCommand(
-                $container->get('config')['sensu-config-directory'],
+                $container->get(SensuConfigService::class),
                 $container->get(SensuApiService::class),
                 $container->get('config')['slack-url'],
                 $container->get('config')['slack-channel']

--- a/js/components/App.js
+++ b/js/components/App.js
@@ -1,9 +1,11 @@
 import React, {useState, useEffect} from 'react';
 import axios from 'axios';
 import DisplaySensorStatus from "./display/DisplaySensorStatus";
+import DisplaySensorsThatHaveNeverRun from "./display/DisplaySensorsThatHaveNeverRun";
 
 export const App = () => {
     const [data, setData] = useState("");
+    const [newSensors, setNewSensors] = useState("");
 
     useEffect(() => {
         var config = require('../../config');
@@ -35,10 +37,17 @@ export const App = () => {
         }).catch(e=>{
             console.log(e);
         });
+
+        axios.get(config["base-url"] + '/newSensors').then(res => {
+            setNewSensors(res.data);
+        }).catch(e=>{
+            console.log(e);
+        });
     }, []);
 
     return (
         <div>
+            <DisplaySensorsThatHaveNeverRun data={newSensors} />
             <DisplaySensorStatus data={data} />
         </div>
     )

--- a/js/components/display/DisplaySensorsThatHaveNeverRun.js
+++ b/js/components/display/DisplaySensorsThatHaveNeverRun.js
@@ -1,0 +1,18 @@
+import React from 'react'
+
+const DisplaySensorsThatHaveNeverRun = ({data}) => {
+    //needs changing to be async
+    if (!data) {
+        return <div/>
+    }
+
+    let sensorString = data.join(', ')
+
+    return (
+        <div className="newSensorsWarning">
+            <strong>Warning - the following sensors have never run: </strong>
+                {sensorString}
+        </div>
+    )
+}
+export default DisplaySensorsThatHaveNeverRun;

--- a/src/Controller/CheckResultsController.php
+++ b/src/Controller/CheckResultsController.php
@@ -34,4 +34,12 @@ class CheckResultsController
 
         return $response->withHeader('Content-type', 'application/vnd.api+json')->withBody($stream);
     }
+
+    public function getSensorsThatHaveNeverRun(ServerRequestInterface $request, ResponseInterface $response, array $args)
+    {
+        $stream = new Stream(fopen('php://temp', 'r+'));
+        $stream->write(json_encode($this->checkResultService->getSensorsThatHaveNeverRun()));
+
+        return $response->withHeader('Content-type', 'application/vnd.api+json')->withBody($stream);
+    }
 }

--- a/src/Factory/CheckResultsServiceFactory.php
+++ b/src/Factory/CheckResultsServiceFactory.php
@@ -4,14 +4,15 @@ namespace SensuDashboard\Factory;
 
 use Psr\Container\ContainerInterface;
 use SensuDashboard\Service\SensuApiService;
+use SensuDashboard\Service\SensuConfigService;
 
 class CheckResultsServiceFactory
 {
     public function __invoke(ContainerInterface $container)
     {
         $sensuApiBaseUrl = $container->get('config')['sensu-api-base-url'];
-        $sensuConfigDirectory = $container->get('config')['sensu-config-directory'];
+        $sensuConfigService = $container->get(SensuConfigService::class);
 
-        return new SensuApiService($sensuApiBaseUrl, $sensuConfigDirectory);
+        return new SensuApiService($sensuApiBaseUrl, $sensuConfigService);
     }
 }

--- a/src/Factory/CheckResultsServiceFactory.php
+++ b/src/Factory/CheckResultsServiceFactory.php
@@ -10,7 +10,8 @@ class CheckResultsServiceFactory
     public function __invoke(ContainerInterface $container)
     {
         $sensuApiBaseUrl = $container->get('config')['sensu-api-base-url'];
+        $sensuConfigDirectory = $container->get('config')['sensu-config-directory'];
 
-        return new SensuApiService($sensuApiBaseUrl);
+        return new SensuApiService($sensuApiBaseUrl, $sensuConfigDirectory);
     }
 }

--- a/src/Factory/SensuConfigServiceFactory.php
+++ b/src/Factory/SensuConfigServiceFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SensuDashboard\Factory;
+
+use Psr\Container\ContainerInterface;
+use SensuDashboard\Service\SensuConfigService;
+
+class SensuConfigServiceFactory
+{
+    public function __invoke(ContainerInterface $container)
+    {
+        $sensuConfigDirectory = $container->get('config')['sensu-config-directory'];
+
+        return new SensuConfigService($sensuConfigDirectory);
+    }
+}

--- a/src/Service/SensuApiService.php
+++ b/src/Service/SensuApiService.php
@@ -30,14 +30,24 @@ class SensuApiService
      */
     public function getCheckResults()
     {
+        $results = $this->getAllCheckResults();
+
+        return $this->filterOldResults($results);
+    }
+
+    /**
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function getAllCheckResults()
+    {
         $client = new Client();
 
         $request = new Request('GET', $this->sensuApiBaseUrl . "/results");
         $response = $client->send($request, ['timeout' => 2]);
         $results = json_decode($response->getBody()->getContents(), 1);
-        $filteredResults = $this->filterOldResults($results);
 
-        return $filteredResults;
+        return $results;
     }
 
     /**
@@ -102,7 +112,7 @@ class SensuApiService
     {
         $currentSensors = $this->sensuConfigService->getCurrentConfiguredSensors();
 
-        $lastRunResults = $this->getCheckResults();
+        $allRunResults = $this->getAllCheckResults();
 
         $sensorsThatHaveNeverRun = [];
 
@@ -121,7 +131,7 @@ class SensuApiService
                 continue;
             }
 
-            if (!isset($lastRunResults[$key])) {
+            if (!isset($allRunResults[$key])) {
                 $sensorsThatHaveNeverRun[] = $key;
             }
         }

--- a/src/Service/SensuApiService.php
+++ b/src/Service/SensuApiService.php
@@ -3,25 +3,25 @@
 namespace SensuDashboard\Service;
 
 use DateTime;
-use DirectoryIterator;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Request;
+use SensuDashboard\Service\SensuConfigService;
 
 class SensuApiService
 {
     private $sensuApiBaseUrl;
 
-    private $sensuConfigDirectory;
+    private $sensuConfigService;
 
     /**
      * SensuApiService constructor.
      * @param $sensuApiBaseUrl
-     * @param $sensuConfigDirectory
+     * @param $sensuConfigService
      */
-    public function __construct($sensuApiBaseUrl, $sensuConfigDirectory)
+    public function __construct($sensuApiBaseUrl, SensuConfigService $sensuConfigService)
     {
         $this->sensuApiBaseUrl = $sensuApiBaseUrl;
-        $this->sensuConfigDirectory = $sensuConfigDirectory;
+        $this->sensuConfigService = $sensuConfigService;
     }
 
     /**
@@ -100,23 +100,13 @@ class SensuApiService
 
     public function getSensorsThatHaveNeverRun()
     {
-        $directoryIterator = new DirectoryIterator($this->sensuConfigDirectory);
-
-        $sensuConfig = [];
-
-        foreach ($directoryIterator as $file) {
-            if ($file->isDot()) {
-                continue;
-            }
-
-            $sensuConfig[] = json_decode(file_get_contents($file->getPathname()), 1);
-        }
+        $currentSensors = $this->sensuConfigService->getCurrentConfiguredSensors();
 
         $lastRunResults = $this->getCheckResults();
 
         $sensorsThatHaveNeverRun = [];
 
-        foreach ($sensuConfig as $config) {
+        foreach ($currentSensors as $config) {
             if (isset($config['client']) ||
                 isset($config['handlers']) ||
                 isset($config['relay']) ||

--- a/src/Service/SensuConfigService.php
+++ b/src/Service/SensuConfigService.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace SensuDashboard\Service;
+
+use DirectoryIterator;
+
+class SensuConfigService
+{
+    private $sensuConfigDirectory;
+
+    /**
+     * @param $sensuConfigDirectory
+     */
+    public function __construct($sensuConfigDirectory)
+    {
+        $this->sensuConfigDirectory = $sensuConfigDirectory;
+    }
+
+    public function getCurrentConfiguredSensors()
+    {
+        $directoryIterator = new DirectoryIterator($this->sensuConfigDirectory);
+
+        $sensuConfig = [];
+
+        foreach ($directoryIterator as $file) {
+            if ($file->isDot()) {
+                continue;
+            }
+
+            $sensuConfig[] = json_decode(file_get_contents($file->getPathname()), 1);
+        }
+
+        return $sensuConfig;
+    }
+}

--- a/src/dependencies.php
+++ b/src/dependencies.php
@@ -6,7 +6,9 @@ use Monolog\Processor\UidProcessor;
 use SensuDashboard\Controller\CheckResultsController;
 use SensuDashboard\Factory\CheckResultsControllerFactory;
 use SensuDashboard\Factory\CheckResultsServiceFactory;
+use SensuDashboard\Factory\SensuConfigServiceFactory;
 use SensuDashboard\Service\SensuApiService;
+use SensuDashboard\Service\SensuConfigService;
 use Slim\App;
 use Slim\Views\PhpRenderer;
 
@@ -40,6 +42,7 @@ return function (App $app) {
     $container['config'] = $config;
 
 
-    $container[CheckResultsController::class] = new CheckResultsControllerFactory($container);
     $container[SensuApiService::class] = new CheckResultsServiceFactory($container);
+    $container[CheckResultsController::class] = new CheckResultsControllerFactory($container);
+    $container[SensuConfigService::class] = new SensuConfigServiceFactory($container);
 };

--- a/src/routes.php
+++ b/src/routes.php
@@ -12,10 +12,7 @@ return function (App $app) {
     $container = $app->getContainer();
 
     $app->get('/', function (Request $request, Response $response, array $args) use ($container) {
-        $body = $container->get(SensuApiService::class)->getCheckResults();
-
-        // Render index view
-        return $container->get('renderer')->render($response, 'index.phtml', ['body' => $body]);
+        return $container->get('renderer')->render($response, 'index.phtml');
     });
 
     $app->get('/checkResults', CheckResultsController::class . ':getCheckResults');

--- a/src/routes.php
+++ b/src/routes.php
@@ -3,7 +3,6 @@
 use SensuDashboard\Controller\CheckResultsController;
 use SensuDashboard\Controller\MockSensuClientsApiController;
 use SensuDashboard\Controller\MockSensuResultsApiController;
-use SensuDashboard\Service\SensuApiService;
 use Slim\App;
 use Slim\Http\Request;
 use Slim\Http\Response;

--- a/src/routes.php
+++ b/src/routes.php
@@ -16,6 +16,7 @@ return function (App $app) {
     });
 
     $app->get('/checkResults', CheckResultsController::class . ':getCheckResults');
+    $app->get('/newSensors', CheckResultsController::class . ':getSensorsThatHaveNeverRun');
     $app->get('/mock-sensu-api/results', MockSensuResultsApiController::class . ':getCheckResults');
     $app->get('/mock-sensu-api/clients', MockSensuClientsApiController::class . ':getClients');
 };

--- a/templates/index.phtml
+++ b/templates/index.phtml
@@ -187,20 +187,7 @@
     </style>
 </head>
 <body>
-
-    <?php
-
-    foreach ($body as $check) {
-        $dateTime = new DateTime();
-        $dateTime->setTimestamp($check['check']['executed']);
-        //echo "Name: " . $check["check"]["name"] . " Status: " . $check['check']["status"] . " Run at: " . $dateTime->format("d/m/Y H:i:s");
-        //echo "<br />";
-    }
-
-    ?>
-
     <div id="app"></div>
-
     <script src="/assets/js/app.bundle.js"></script>
 </body>
 </html>

--- a/templates/index.phtml
+++ b/templates/index.phtml
@@ -184,6 +184,12 @@
             grid-row-start: auto;
             grid-row-end: auto;
         }
+
+        .newSensorsWarning {
+            color: red;
+            margin-left: 10px;
+            margin-bottom: 30px;
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
Adds a warning to the sensu-dashboard front end for any sensors that have never been run before, so that these don't get lost after we filter them out of the slack channel.